### PR TITLE
Workaround for nullVal and emptyVal in plugin-sdk

### DIFF
--- a/tencentcloud/resource_tc_mysql_privilege.go
+++ b/tencentcloud/resource_tc_mysql_privilege.go
@@ -139,8 +139,12 @@ func resourceTencentCloudMysqlPrivilege() *schema.Resource {
 				Description: "Account host, default is `%`.",
 			},
 			"global": {
-				Type:     schema.TypeSet,
-				Required: true,
+				Type: schema.TypeSet,
+				// Workaround： 将Required变为Optional+Computed.
+				// Issue: plugin sdk 会错误地在create时候把赋值给required的`[]`变为nullVal, 然后在read变回`[]`,
+				//        见 https://github.com/hashicorp/terraform-plugin-sdk/issues/766
+				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set: func(v interface{}) int {
 					return helper.HashString(v.(string))


### PR DESCRIPTION
plugin sdk在create时候将`[]`变为了null，但是在read时会会变成`[]`。这个提交借鉴了阿里云instace的secondary_ip属性的解决方案，通过将受影响的属性设置为Optional+Computed作为workaround。

issue:  https://github.com/hashicorp/terraform-plugin-sdk/issues/766