### PR TITLE
mysql更换subnet触发forcenew

### DIFF
--- a/tencentcloud/resource_tc_mysql_instance.go
+++ b/tencentcloud/resource_tc_mysql_instance.go
@@ -162,8 +162,8 @@ func TencentMsyqlBasicInfo() map[string]*schema.Schema {
 		},
 		"subnet_id": {
 			Type:         schema.TypeString,
-			Optional:     true,
-			Computed:     true,
+			Required:     true,
+			ForceNew:     true,
 			ValidateFunc: validateStringLengthInRange(1, 100),
 			Description:  "Private network ID. If `vpc_id` is set, this value is required.",
 		},


### PR DESCRIPTION
# 问题
mysql数据库发生subnet变更只会触发update，但是subnet有可能正在销毁重建。此时由于subnet内仍有一个mysql导致无法销毁subnet。且此时更换subnet导致ip地址等也处于未知状态。
核心问题是terraform的update操作不会遵循资源的依赖关系。

# 方案
mysql的subnet属性变为forcenew，这样会先销毁mysql然后重建subnet。