### PR TITLE
add stock ip bandwidth to nat gw

### DIFF
--- a/tencentcloud/resource_tc_nat_gateway.go
+++ b/tencentcloud/resource_tc_nat_gateway.go
@@ -133,7 +133,8 @@ func resourceTencentCloudNatGatewayCreate(d *schema.ResourceData, meta interface
 			request.Tags = append(request.Tags, &tag)
 		}
 	}
-
+	eipBandwidth := uint64(2000)
+	request.StockPublicIpAddressesBandwidthOut = &eipBandwidth
 	var response *vpc.CreateNatGatewayResponse
 	err := resource.Retry(readRetryTimeout, func() *resource.RetryError {
 		result, e := meta.(*TencentCloudClient).apiV3Conn.UseVpcClient().CreateNatGateway(request)


### PR DESCRIPTION
# 背景
腾讯云的nat gateway在解绑和绑定eip后会自动设置eip带宽为1Mbps。根据客服工单，22年以前的老客户调用api会默认调整为最大带宽，而我们的账户不会。

# 方案
腾讯云api在创建nat gateway的时候提供接口设置eip带宽，但是terraform资源并未添加此接口。
此PR添加了接口调整nat gateway的eip带宽。