### PR TITLE
mysql允许外部绑定安全组，因此安全组应为computed

### DIFF
--- a/tencentcloud/resource_tc_mysql_instance.go
+++ b/tencentcloud/resource_tc_mysql_instance.go
@@ -171,6 +171,7 @@ func TencentMsyqlBasicInfo() map[string]*schema.Schema {
 		"security_groups": {
 			Type:     schema.TypeSet,
 			Optional: true,
+			Computed: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Set: func(v interface{}) int {
 				return helper.HashString(v.(string))


### PR DESCRIPTION
# 背景
mysql实例安全组之前未optional，但是cdk使用attachment绑定安全组。因此再第二次部署的时候mysql资源会发现自己有安全组 但是配置文件里要求没有安全组。此时会将attach上去的安全组解绑，造成错误配置。

# 方案
将mysql资源的安全组设置为optional，computed，防止read出来的外部attachment造成抖动