### PR TITLE
更换磁盘snapshot应触发销毁重建

### DIFF
--- a/tencentcloud/resource_tc_cbs_storage.go
+++ b/tencentcloud/resource_tc_cbs_storage.go
@@ -105,7 +105,7 @@ func resourceTencentCloudCbsStorage() *schema.Resource {
 			"snapshot_id": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Computed:    true,
+				ForceNew:    true,
 				Description: "ID of the snapshot. If specified, created the CBS by this snapshot.",
 			},
 			"project_id": {


### PR DESCRIPTION
# 背景
当前腾讯云调用applysnapshot接口必须已经解除挂载且快照只能apply到原磁盘。如果需要复制快照数据到其它云硬盘上，需要使用[CreateDisks](https://cloud.tencent.com/document/product/362/16312)接口创建新的弹性云盘，将快照数据复制到新购云盘上。

# 方案
snapshot id调整为forcenew，这样可以通过依赖触发停止业务服务并无需确保快照与硬盘的对应关系

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 更新了快照ID字段的属性，从`Computed: true`改为`ForceNew: true`，在基于快照ID创建CBS时生效。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->