### PR TITLE
修复api无法清空已有健康检查设置

### DIFF
--- a/.github/workflows/shinny_release.yml
+++ b/.github/workflows/shinny_release.yml
@@ -40,7 +40,7 @@ jobs:
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
-          version: latest
+          version: 1.26.2
           args: release --clean --timeout 500m --parallelism 1 --config .goreleaser.shinny.yml ${{ env.grflags }}
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION
# 背景
腾讯云的clb监听器api无法消除已经配置的健康检查，经过客服确认只能通过重建进行消除

# 方案
使用CustomizeDiff判断健康检查相关项变为空后触发ForceNew

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **新功能**
	- 引入了健康检查参数的自定义差异检查，确保在修改关键健康检查配置时，资源会被强制重新创建以维护配置的完整性。
- **改进**
	- 更新GitHub Actions工作流配置，锁定GoReleaser的版本为1.26.2，以提高发布过程的稳定性和可预测性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->