### PR TITLE
clb监听器后端参数提供默认值避免配置飘移

### DIFF
--- a/tencentcloud/resource_tc_clb_attachment.go
+++ b/tencentcloud/resource_tc_clb_attachment.go
@@ -1,23 +1,25 @@
 /*
 Provides a resource to create a CLB attachment.
 
-Example Usage
+# Example Usage
 
 ```hcl
-resource "tencentcloud_clb_attachment" "foo" {
-  clb_id      = "lb-k2zjp9lv"
-  listener_id = "lbl-hh141sn9"
-  rule_id     = "loc-4xxr2cy7"
 
-  targets {
-    instance_id = "ins-1flbqyp8"
-    port        = 80
-    weight      = 10
-  }
-}
+	resource "tencentcloud_clb_attachment" "foo" {
+	  clb_id      = "lb-k2zjp9lv"
+	  listener_id = "lbl-hh141sn9"
+	  rule_id     = "loc-4xxr2cy7"
+
+	  targets {
+	    instance_id = "ins-1flbqyp8"
+	    port        = 80
+	    weight      = 10
+	  }
+	}
+
 ```
 
-Import
+# Import
 
 CLB attachment can be imported using the id, e.g.
 
@@ -86,11 +88,13 @@ func resourceTencentCloudClbServerAttachment() *schema.Resource {
 						"instance_id": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							Default:     "",
 							Description: "CVM Instance Id of the backend server, conflict with `eni_ip` but must specify one of them.",
 						},
 						"eni_ip": {
 							Type:        schema.TypeString,
 							Optional:    true,
+							Default:     "",
 							Description: "Eni IP address of the backend server, conflict with `instance_id` but must specify one of them.",
 						},
 						"port": {


### PR DESCRIPTION
clb 在删除和减少listener的时候出现了配置检查错误，由于terraform的 nullvalue 和 zerovalue 造成了变动从而引发 consul key 资源记录的变更，严重影响服务的部署
https://github.com/hashicorp/terraform/issues/21901
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **文档**
	- 改进了代码注释的可读性
	- 为 `targets` 模式中的 `instance_id` 和 `eni_ip` 字段添加了默认空字符串值

- **样式**
	- 调整了示例用法的缩进格式

<!-- end of auto-generated comment: release notes by coderabbit.ai -->