### PR TITLE
更换镜像后等待操作完成后进行下一步操作

### DIFF
--- a/tencentcloud/service_tencentcloud_cvm.go
+++ b/tencentcloud/service_tencentcloud_cvm.go
@@ -288,7 +288,7 @@ func (me *CvmService) ModifyInstanceType(ctx context.Context, instanceId, instan
 	logId := getLogId(ctx)
 	// 根据文档 https://cloud.tencent.com/document/api/213/15744 中的建议，先停止实例再修改实例类型
 	err := me.StopInstance(ctx, instanceId, "KEEP_CHARGING")
-	if err != nil {
+	if err != nil && !isExpectError(err, []string{"UnsupportedOperation.InstanceStateStopped"}) {
 		return err
 	}
 	err = resource.Retry(2*readRetryTimeout, func() *resource.RetryError {


### PR DESCRIPTION
resolve: https://github.com/shinnytech/terraform-provider-tencentcloud/pull/22#issuecomment-2594758192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 改进了实例重置操作的可靠性，通过添加等待机制确保操作完全完成后再继续执行后续步骤。
  - 优化了修改实例类型的方法的错误处理逻辑，使其能够优雅地处理特定的预期错误，而不会提前终止操作。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->