### PR TITLE
eni: mark security_group as list instead of set as the order does matter

### DIFF
--- a/tencentcloud/resource_tc_eni.go
+++ b/tencentcloud/resource_tc_eni.go
@@ -106,10 +106,9 @@ func resourceTencentCloudEni() *schema.Resource {
 				Description:  "Description of the ENI, maximum length 60.",
 			},
 			"security_groups": {
-				Type:        schema.TypeSet,
+				Type:        schema.TypeList,
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				Set:         schema.HashString,
 				Description: "A set of security group IDs.",
 			},
 			"ipv4s": {
@@ -202,7 +201,7 @@ func resourceTencentCloudEniCreate(d *schema.ResourceData, m interface{}) error 
 	)
 
 	if raw, ok := d.GetOk("security_groups"); ok {
-		securityGroups = helper.InterfacesStrings(raw.(*schema.Set).List())
+		securityGroups = helper.InterfacesStrings(raw.([]interface{}))
 	}
 
 	if raw, ok := d.GetOk("ipv4s"); ok {
@@ -446,7 +445,7 @@ func resourceTencentCloudEniUpdate(d *schema.ResourceData, m interface{}) error 
 	if d.HasChange("security_groups") {
 		updateAttrs = append(updateAttrs, "security_groups")
 	}
-	sgs = helper.InterfacesStrings(d.Get("security_groups").(*schema.Set).List())
+	sgs = helper.InterfacesStrings(d.Get("security_groups").([]interface{}))
 
 	if len(updateAttrs) > 0 {
 		if err := vpcService.ModifyEniAttribute(ctx, id, name, desc, sgs); err != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **修复**
  - 优化了“安全组”属性的处理方式，提高了相关操作的兼容性和稳定性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->